### PR TITLE
Rounded eraser in android

### DIFF
--- a/android/src/main/java/com/reactlibrary/ScratchView.java
+++ b/android/src/main/java/com/reactlibrary/ScratchView.java
@@ -74,6 +74,7 @@ public class ScratchView extends View implements View.OnTouchListener {
 
         pathPaint.setAlpha(0);
         pathPaint.setStyle(Paint.Style.STROKE);
+        pathPaint.setStrokeCap(Paint.Cap.ROUND);
         pathPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
         pathPaint.setAntiAlias(true);
 

--- a/android/src/main/java/com/reactlibrary/ScratchView.java
+++ b/android/src/main/java/com/reactlibrary/ScratchView.java
@@ -74,6 +74,7 @@ public class ScratchView extends View implements View.OnTouchListener {
 
         pathPaint.setAlpha(0);
         pathPaint.setStyle(Paint.Style.STROKE);
+        pathPaint.setStrokeJoin(Paint.Join.ROUND);
         pathPaint.setStrokeCap(Paint.Cap.ROUND);
         pathPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
         pathPaint.setAntiAlias(true);


### PR DESCRIPTION
I observed that when you scratch in android, it the edges looked sharp and rectangular. Setting this flag to the Paint object will change the eraser shape to a circle and make it look smoother